### PR TITLE
Minor UI changes to improve screenshots in the docs

### DIFF
--- a/iot-hub/Samples/device/AndroidSample/app/src/main/res/layout/activity_main.xml
+++ b/iot-hub/Samples/device/AndroidSample/app/src/main/res/layout/activity_main.xml
@@ -111,7 +111,7 @@
         android:layout_height="25dp"
         android:layout_alignStart="@+id/txtMsgsSent"
         android:layout_below="@+id/txtMsgsReceived"
-        android:text="Last Temperature Reading (C):"
+        android:text="Last Temp. Reading (C):"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
     <TextView
@@ -130,7 +130,7 @@
         android:layout_height="25dp"
         android:layout_alignStart="@+id/txtMsgsSent"
         android:layout_below="@+id/txtLastTemp"
-        android:text="Last Humidity Reading (%)"
+        android:text="Last Humidity Reading (%):"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
     <TextView
@@ -161,7 +161,12 @@
         android:gravity="center_vertical"
         android:text="{none}"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:textColor="@android:color/holo_blue_dark" />
+        android:textColor="@android:color/holo_blue_dark"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="12sp"
+        android:autoSizeMaxTextSize="14sp"
+        android:autoSizeStepGranularity="2sp"/>
 
     <TextView
         android:id="@+id/txtLastMsgReceived"
@@ -181,6 +186,12 @@
         android:gravity="center_vertical"
         android:text="{none}"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:textColor="@android:color/holo_blue_dark" />
+        android:textColor="@android:color/holo_blue_dark"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="12sp"
+        android:autoSizeMaxTextSize="14sp"
+        android:autoSizeStepGranularity="2sp"/>
+
 
 </RelativeLayout>


### PR DESCRIPTION
## Purpose

Minor UI update based on physical device testing (Galaxy S7 Edge). 
This change prevents a UI label from overwriting a run-time value in the UI.  
Also, this change prevents line wrapping of the last payload displayed.

These changes are made to improve [this documentation for the sample](https://review.docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-android?branch=pr-en-us-57914).

This screenshot below shows the final screenshot updates based on these changes

![Screenshot](https://github.com/wesmc7777/azure-docs-pr/blob/android-telemetry/articles/iot-hub/media/quickstart-send-telemetry-android/sample-screenshot.png?raw=true)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->