### PR TITLE
Update IoT Hub sample to use new Events Hubs API

### DIFF
--- a/iot-hub/Quickstarts/read-d2c-messages/README.md
+++ b/iot-hub/Quickstarts/read-d2c-messages/README.md
@@ -1,0 +1,35 @@
+# Notes
+
+This sample demonstrates how to use the Microsoft Azure Event Hubs Client for Java to 
+read messages sent from a device by using the built-in event hubs that exists by default for
+every Iot Hub instance. 
+
+## Get Event Hubs-compatible connection string
+
+You can get the Event Hubs-compatible connection string to your IotHub instance via the Azure portal or
+by using the Azure CLI.
+
+If using the Azure portal, see [Built in endpoints for IotHub](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-read-builtin#read-from-the-built-in-endpoint) to get the Event Hubs-compatible
+connection string and assign it to the constant `connectionString` in the sample. You can skip the Azure CLI
+instructions in the sample after this.
+
+If using the Azure CLI, you will need to run the following commands before running this sample to get 
+the details required to form the Event Hubs compatible connection string.
+
+- `az iot hub show --query properties.eventHubEndpoints.events.endpoint --name {your IoT Hub name}`
+- `az iot hub show --query properties.eventHubEndpoints.events.path --name {your IoT Hub name}`
+- `az iot hub policy show --name service --query primaryKey --hub-name {your IoT Hub name}`
+
+## Checkpointing
+
+For an example that uses checkpointing, follow up this sample with the [sample that uses
+Azure Storage Blob to create checkpoints](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/samples/java/com/azure/messaging/eventhubs/checkpointstore/blob/EventProcessorBlobCheckpointStoreSample.java).
+
+Note that this requires adding a new dependency in your `pom.xml` to use the [Azure Storage Blob checkpoint store](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/README.md).
+
+## WebSocket and proxy
+
+If using WebSockets, configure the `EventHubClientBuilder` to use transport type `AmqpTransportType.AMQP_WEB_SOCKETS`.
+
+If your application runs behind a proxy server, then you need to configure the proxy options and set the transport 
+type to `AmqpTransportType.AMQP_WEB_SOCKETS` as shown in [the sample](./src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java). 

--- a/iot-hub/Quickstarts/read-d2c-messages/README.md
+++ b/iot-hub/Quickstarts/read-d2c-messages/README.md
@@ -31,5 +31,6 @@ Note that this requires adding a new dependency in your `pom.xml` to use the [Az
 
 If using WebSockets, configure the `EventHubClientBuilder` to use transport type `AmqpTransportType.AMQP_WEB_SOCKETS`.
 
-If your application runs behind a proxy server, then you need to configure the proxy options and set the transport 
-type to `AmqpTransportType.AMQP_WEB_SOCKETS` as shown in [the sample](./src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java). 
+If your application runs behind a proxy server, then, in addition to setting the transport type to 
+AmqpTransportType.AMQP_WEB_SOCKETS, you also need to configure the proxy options as shown in the setupProxy method in 
+[the sample](./src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java).

--- a/iot-hub/Quickstarts/read-d2c-messages/README.md
+++ b/iot-hub/Quickstarts/read-d2c-messages/README.md
@@ -32,5 +32,5 @@ Note that this requires adding a new dependency in your `pom.xml` to use the [Az
 If using WebSockets, configure the `EventHubClientBuilder` to use transport type `AmqpTransportType.AMQP_WEB_SOCKETS`.
 
 If your application runs behind a proxy server, then, in addition to setting the transport type to 
-AmqpTransportType.AMQP_WEB_SOCKETS, you also need to configure the proxy options as shown in the setupProxy method in 
+`AmqpTransportType.AMQP_WEB_SOCKETS`, you also need to configure the proxy options as shown in the setupProxy method in 
 [the sample](./src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java).

--- a/iot-hub/Quickstarts/read-d2c-messages/README.md
+++ b/iot-hub/Quickstarts/read-d2c-messages/README.md
@@ -32,5 +32,5 @@ Note that this requires adding a new dependency in your `pom.xml` to use the [Az
 If using WebSockets, configure the `EventHubClientBuilder` to use transport type `AmqpTransportType.AMQP_WEB_SOCKETS`.
 
 If your application runs behind a proxy server, then, in addition to setting the transport type to 
-`AmqpTransportType.AMQP_WEB_SOCKETS`, you also need to configure the proxy options as shown in the setupProxy method in 
+`AmqpTransportType.AMQP_WEB_SOCKETS`, you also need to configure the proxy options as shown in the `setupProxy` method in 
 [the sample](./src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java).

--- a/iot-hub/Quickstarts/read-d2c-messages/pom.xml
+++ b/iot-hub/Quickstarts/read-d2c-messages/pom.xml
@@ -12,14 +12,9 @@
   <name>Read device-to-cloud messages</name>
   <dependencies>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-eventhubs</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-eventhubs-eph</artifactId>
-      <version>1.0.0</version>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-messaging-eventhubs</artifactId>
+      <version>5.1.0</version>
     </dependency>
   </dependencies>
   <properties>

--- a/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
+++ b/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
@@ -74,21 +74,21 @@ public class ReadDeviceToCloudMessages {
   }
 
   /**
-   * This method receives events from all partitions asynchronously starting from the earliest available event in
+   * This method receives events from all partitions asynchronously starting from the newly available events in
    * each partition.
    *
    * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
    */
   private static void receiveFromAllPartitions(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
-    System.out.println("Receiving events from all partitions");
 
     eventHubConsumerAsyncClient
-        .receive(true) // set this to false to read only the newly available events
+        .receive(false) // set this to false to read only the newly available events
         .subscribe(partitionEvent -> {
-          System.out.printf("Telemetry received from partition %s:%n%s",
+          System.out.printf("%nTelemetry received from partition %s:%n%s",
               partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
-          System.out.printf("%nApplication properties (set by device):%n" + partitionEvent.getData().getProperties());
-          System.out.printf("%nSystem properties (set by IoT Hub):%n" + partitionEvent.getData().getSystemProperties());
+          System.out.printf("%nApplication properties (set by device):%n%s", partitionEvent.getData().getProperties());
+          System.out.printf("%nSystem properties (set by IoT Hub):%n%s",
+              partitionEvent.getData().getSystemProperties());
         }, ex -> {
           System.out.println("Error receiving events " + ex);
         }, () -> {
@@ -98,24 +98,24 @@ public class ReadDeviceToCloudMessages {
 
   /**
    * This method queries all available partitions in the Event Hub and picks a single partition to receive
-   * events asynchronously starting from the earliest available event in that partition.
+   * events asynchronously starting from the newly available event in that partition.
    *
    * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
    */
   private static void receiveFromSinglePartition(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
-    System.out.println("Receiving events from a single partition");
     eventHubConsumerAsyncClient
         .getPartitionIds() // get all available partitions
         .take(1) // pick a single partition
         .flatMap(partitionId -> {
           System.out.println("Receiving events from partition id " + partitionId);
           return eventHubConsumerAsyncClient
-              .receiveFromPartition(partitionId, EventPosition.earliest());
+              .receiveFromPartition(partitionId, EventPosition.latest());
         }).subscribe(partitionEvent -> {
-          System.out.printf("Telemetry received from partition %s: %s %n",
+          System.out.printf("%nTelemetry received from partition %s:%n%s",
               partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
-          System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
-          System.out.println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+          System.out.printf("%nApplication properties (set by device):%n%s", partitionEvent.getData().getProperties());
+          System.out.printf("%nSystem properties (set by IoT Hub):%n%s",
+              partitionEvent.getData().getSystemProperties());
         }, ex -> {
           System.out.println("Error receiving events " + ex);
         }, () -> {
@@ -126,28 +126,28 @@ public class ReadDeviceToCloudMessages {
 
   /**
    * This method queries all available partitions in the Event Hub and picks a single partition to receive
-   * events asynchronously in batches of 100 events, starting from the earliest available event in that partition.
+   * events asynchronously in batches of 100 events, starting from the newly available event in that partition.
    *
    * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
    */
   private static void receiveFromSinglePartitionInBatches(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
     int batchSize = 100;
-    System.out.printf("Receiving events in batches of %s events from a single partition %n", batchSize);
     eventHubConsumerAsyncClient
         .getPartitionIds()
         .take(1)
         .flatMap(partitionId -> {
           System.out.println("Receiving events from partition id " + partitionId);
           return eventHubConsumerAsyncClient
-              .receiveFromPartition(partitionId, EventPosition.earliest());
+              .receiveFromPartition(partitionId, EventPosition.latest());
         }).window(batchSize) // batch the events
         .subscribe(partitionEvents -> {
               partitionEvents.toIterable().forEach(partitionEvent -> {
-                System.out.printf("Telemetry received from partition %s: %s %n",
+                System.out.printf("%nTelemetry received from partition %s:%n%s",
                     partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
-                System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
-                System.out
-                    .println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+                System.out.printf("%nApplication properties (set by device):%n%s",
+                    partitionEvent.getData().getProperties());
+                System.out.printf("%nSystem properties (set by IoT Hub):%n%s",
+                        partitionEvent.getData().getSystemProperties());
               });
             }, ex -> {
               System.out.println("Error receiving events " + ex);

--- a/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
+++ b/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
@@ -2,114 +2,178 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This application uses the Microsoft Azure Event Hubs Client for Java
-// For samples see: https://github.com/Azure/azure-event-hubs/tree/master/samples/Java
-// For documenation see: https://docs.microsoft.com/azure/event-hubs/
+// For samples see: https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/eventhubs/azure-messaging-eventhubs/src/samples
+// For documentation see: https://docs.microsoft.com/azure/event-hubs/
 
 package com.microsoft.docs.iothub.samples;
 
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.EventHubException;
-import com.microsoft.azure.eventhubs.EventPosition;
-import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
+import com.azure.core.amqp.AmqpTransportType;
+import com.azure.core.amqp.ProxyAuthenticationType;
+import com.azure.core.amqp.ProxyOptions;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
+import com.azure.messaging.eventhubs.EventHubConsumerAsyncClient;
+import com.azure.messaging.eventhubs.models.EventPosition;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.nio.charset.Charset;
-import java.net.URI;
-import java.net.URISyntaxException;
-
+/**
+ * A sample demonstrating how to receive events from Event Hubs sent from an IoT Hub device.
+ */
 public class ReadDeviceToCloudMessages {
 
+  private static final String EH_COMPATIBLE_CONNECTION_STRING_FORMAT = "Endpoint=%s/;EntityPath=%s;"
+      + "SharedAccessKeyName=%s;SharedAccessKey=%s";
+
   // az iot hub show --query properties.eventHubEndpoints.events.endpoint --name {your IoT Hub name}
-  private static final String eventHubsCompatibleEndpoint = "{your Event Hubs compatible endpoint}";
+  private static final String EVENT_HUBS_COMPATIBLE_ENDPOINT = "{your Event Hubs compatible endpoint}";
 
   // az iot hub show --query properties.eventHubEndpoints.events.path --name {your IoT Hub name}
-  private static final String eventHubsCompatiblePath = "{your Event Hubs compatible name}";
+  private static final String EVENT_HUBS_COMPATIBLE_PATH = "{your Event Hubs compatible name}";
 
   // az iot hub policy show --name service --query primaryKey --hub-name {your IoT Hub name}
-  private static final String iotHubSasKey = "{your service primary key}";
-  private static final String iotHubSasKeyName = "service";
+  private static final String IOT_HUB_SAS_KEY = "{your service primary key}";
+  private static final String IOT_HUB_SAS_KEY_NAME = "service";
 
-  // Track all the PartitionReciever instances created.
-  private static ArrayList<PartitionReceiver> receivers = new ArrayList<PartitionReceiver>();
+  /**
+   * The main method to start the sample application that receives events from Event Hubs sent from an IoT Hub device.
+   *
+   * @param args ignored args.
+   * @throws Exception if there's an error running the application.
+   */
+  public static void main(String[] args) throws Exception {
 
-  // Asynchronously create a PartitionReceiver for a partition and then start 
-  // reading any messages sent from the simulated client.
-  private static void receiveMessages(EventHubClient ehClient, String partitionId)
-      throws EventHubException, ExecutionException, InterruptedException {
+    // Build the Event Hubs compatible connection string.
+    String eventHubCompatibleConnectionString = String.format(EH_COMPATIBLE_CONNECTION_STRING_FORMAT,
+        EVENT_HUBS_COMPATIBLE_ENDPOINT, EVENT_HUBS_COMPATIBLE_PATH, IOT_HUB_SAS_KEY_NAME, IOT_HUB_SAS_KEY);
 
-    final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    // Setup the EventHubBuilder by configuring various options as needed.
+    EventHubClientBuilder eventHubClientBuilder = new EventHubClientBuilder()
+        .consumerGroup(EventHubClientBuilder.DEFAULT_CONSUMER_GROUP_NAME)
+        .connectionString(eventHubCompatibleConnectionString);
 
-    // Create the receiver using the default consumer group.
-    // For the purposes of this sample, read only messages sent since 
-    // the time the receiver is created. Typically, you don't want to skip any messages.
-    ehClient.createReceiver(EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, partitionId,
-        EventPosition.fromEnqueuedTime(Instant.now())).thenAcceptAsync(receiver -> {
-          System.out.println(String.format("Starting receive loop on partition: %s", partitionId));
-          System.out.println(String.format("Reading messages sent since: %s", Instant.now().toString()));
+    // uncomment to setup proxy
+    // setupProxy(eventHubClientBuilder);
 
-          receivers.add(receiver);
+    // uncomment to use Web Sockets
+    // eventHubClientBuilder.transportType(AmqpTransportType.AMQP_WEB_SOCKETS);
 
-          while (true) {
-            try {
-              // Check for EventData - this methods times out if there is nothing to retrieve.
-              Iterable<EventData> receivedEvents = receiver.receiveSync(100);
+    // Create an async consumer client as configured in the builder.
+    try (EventHubConsumerAsyncClient eventHubConsumerAsyncClient = eventHubClientBuilder.buildAsyncConsumerClient()) {
 
-              // If there is data in the batch, process it.
-              if (receivedEvents != null) {
-                for (EventData receivedEvent : receivedEvents) {
-                  System.out.println(String.format("Telemetry received:\n %s",
-                      new String(receivedEvent.getBytes(), Charset.defaultCharset())));
-                  System.out.println(String.format("Application properties (set by device):\n%s",receivedEvent.getProperties().toString()));
-                  System.out.println(String.format("System properties (set by IoT Hub):\n%s\n",receivedEvent.getSystemProperties().toString()));
-                }
-              }
-            } catch (EventHubException e) {
-              System.out.println("Error reading EventData");
-            }
-          }
-        }, executorService);
+      receiveFromAllPartitions(eventHubConsumerAsyncClient);
+
+      // uncomment to run these samples
+      // receiveFromSinglePartition(eventHubConsumerAsyncClient);
+      // receiveFromSinglePartitionInBatches(eventHubConsumerAsyncClient);
+
+      // Shut down cleanly.
+      System.out.println("Press ENTER to exit.");
+      System.in.read();
+      System.out.println("Shutting down...");
+    }
   }
 
-  public static void main(String[] args)
-      throws EventHubException, ExecutionException, InterruptedException, IOException, URISyntaxException {
+  /**
+   * This method receives events from all partitions asynchronously starting from the earliest available event in
+   * each partition.
+   *
+   * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
+   */
+  private static void receiveFromAllPartitions(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
+    System.out.println("Receiving events from all partitions");
 
-    final ConnectionStringBuilder connStr = new ConnectionStringBuilder()
-        .setEndpoint(new URI(eventHubsCompatibleEndpoint))
-        .setEventHubName(eventHubsCompatiblePath)
-        .setSasKeyName(iotHubSasKeyName)
-        .setSasKey(iotHubSasKey);
+    eventHubConsumerAsyncClient
+        .receive(true) // set this to false to read only the newly available events
+        .subscribe(partitionEvent -> {
+          System.out.printf("Telemetry received from partition %s: %s%n ",
+              partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
+          System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
+          System.out.println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+        }, ex -> {
+          System.out.println("Error receiving events " + ex);
+        }, () -> {
+          System.out.println("Completed receiving events");
+        });
+  }
 
-    // Create an EventHubClient instance to connect to the
-    // IoT Hub Event Hubs-compatible endpoint.
-    final ExecutorService executorService = Executors.newSingleThreadExecutor();
-    final EventHubClient ehClient = EventHubClient.createSync(connStr.toString(), executorService);
+  /**
+   * This method queries all available partitions in the Event Hub and picks a single partition to receive
+   * events asynchronously starting from the earliest available event in that partition.
+   *
+   * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
+   */
+  private static void receiveFromSinglePartition(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
+    System.out.println("Receiving events from a single partition");
+    eventHubConsumerAsyncClient
+        .getPartitionIds() // get all available partitions
+        .take(1) // pick a single partition
+        .flatMap(partitionId -> {
+          System.out.println("Receiving events from partition id " + partitionId);
+          return eventHubConsumerAsyncClient
+              .receiveFromPartition(partitionId, EventPosition.earliest());
+        }).subscribe(partitionEvent -> {
+          System.out.printf("Telemetry received from partition %s: %s %n",
+              partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
+          System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
+          System.out.println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+        }, ex -> {
+          System.out.println("Error receiving events " + ex);
+        }, () -> {
+          System.out.println("Completed receiving events");
+        }
+    );
+  }
 
-    // Use the EventHubRunTimeInformation to find out how many partitions 
-    // there are on the hub.
-    final EventHubRuntimeInformation eventHubInfo = ehClient.getRuntimeInformation().get();
+  /**
+   * This method queries all available partitions in the Event Hub and picks a single partition to receive
+   * events asynchronously in batches of 100 events, starting from the earliest available event in that partition.
+   *
+   * @param eventHubConsumerAsyncClient The {@link EventHubConsumerAsyncClient}.
+   */
+  private static void receiveFromSinglePartitionInBatches(EventHubConsumerAsyncClient eventHubConsumerAsyncClient) {
+    int batchSize = 100;
+    System.out.printf("Receiving events in batches of %s events from a single partition %n", batchSize);
+    eventHubConsumerAsyncClient
+        .getPartitionIds()
+        .take(1)
+        .flatMap(partitionId -> {
+          System.out.println("Receiving events from partition id " + partitionId);
+          return eventHubConsumerAsyncClient
+              .receiveFromPartition(partitionId, EventPosition.earliest());
+        }).window(batchSize) // batch the events
+        .subscribe(partitionEvents -> {
+              partitionEvents.toIterable().forEach(partitionEvent -> {
+                System.out.printf("Telemetry received from partition %s: %s %n",
+                    partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
+                System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
+                System.out
+                    .println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+              });
+            }, ex -> {
+              System.out.println("Error receiving events " + ex);
+            }, () -> {
+              System.out.println("Completed receiving events");
+            }
+        );
+  }
 
-    // Create a PartitionReciever for each partition on the hub.
-    for (String partitionId : eventHubInfo.getPartitionIds()) {
-      receiveMessages(ehClient, partitionId);
-    }
+  /**
+   * This method sets up proxy options and updates the {@link EventHubClientBuilder}.
+   *
+   * @param eventHubClientBuilder The {@link EventHubClientBuilder}.
+   */
+  private static void setupProxy(EventHubClientBuilder eventHubClientBuilder) {
+    int proxyPort = 8000; // replace with right proxy port
+    String proxyHost = "{hostname}";
+    Proxy proxyAddress = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+    String userName = "{username}";
+    String password = "{password}";
+    ProxyOptions proxyOptions = new ProxyOptions(ProxyAuthenticationType.BASIC, proxyAddress,
+        userName, password);
 
-    // Shut down cleanly.
-    System.out.println("Press ENTER to exit.");
-    System.in.read();
-    System.out.println("Shutting down...");
-    for (PartitionReceiver receiver : receivers) {
-      receiver.closeSync();
-    }
-    ehClient.closeSync();
-    executorService.shutdown();
-    System.exit(0);
+    eventHubClientBuilder.proxyOptions(proxyOptions);
+
+    // To use proxy, the transport type has to be Web Sockets.
+    eventHubClientBuilder.transportType(AmqpTransportType.AMQP_WEB_SOCKETS);
   }
 }

--- a/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
+++ b/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
@@ -85,10 +85,10 @@ public class ReadDeviceToCloudMessages {
     eventHubConsumerAsyncClient
         .receive(true) // set this to false to read only the newly available events
         .subscribe(partitionEvent -> {
-          System.out.printf("Telemetry received from partition %s: %s%n ",
+          System.out.printf("Telemetry received from partition %s:%n%s",
               partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
-          System.out.println("Application properties (set by device): " + partitionEvent.getData().getProperties());
-          System.out.println("System properties (set by IoT Hub): " + partitionEvent.getData().getSystemProperties());
+          System.out.printf("%nApplication properties (set by device):%n" + partitionEvent.getData().getProperties());
+          System.out.printf("%nSystem properties (set by IoT Hub):%n" + partitionEvent.getData().getSystemProperties());
         }, ex -> {
           System.out.println("Error receiving events " + ex);
         }, () -> {

--- a/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
+++ b/iot-hub/Quickstarts/read-d2c-messages/src/main/java/com/microsoft/docs/iothub/samples/ReadDeviceToCloudMessages.java
@@ -84,6 +84,7 @@ public class ReadDeviceToCloudMessages {
     eventHubConsumerAsyncClient
         .receive(false) // set this to false to read only the newly available events
         .subscribe(partitionEvent -> {
+          System.out.println();
           System.out.printf("%nTelemetry received from partition %s:%n%s",
               partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
           System.out.printf("%nApplication properties (set by device):%n%s", partitionEvent.getData().getProperties());
@@ -111,6 +112,7 @@ public class ReadDeviceToCloudMessages {
           return eventHubConsumerAsyncClient
               .receiveFromPartition(partitionId, EventPosition.latest());
         }).subscribe(partitionEvent -> {
+          System.out.println();
           System.out.printf("%nTelemetry received from partition %s:%n%s",
               partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
           System.out.printf("%nApplication properties (set by device):%n%s", partitionEvent.getData().getProperties());
@@ -142,6 +144,7 @@ public class ReadDeviceToCloudMessages {
         }).window(batchSize) // batch the events
         .subscribe(partitionEvents -> {
               partitionEvents.toIterable().forEach(partitionEvent -> {
+                System.out.println();
                 System.out.printf("%nTelemetry received from partition %s:%n%s",
                     partitionEvent.getPartitionContext().getPartitionId(), partitionEvent.getData().getBodyAsString());
                 System.out.printf("%nApplication properties (set by device):%n%s",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
The current sample to demonstrate reading events from an Event Hub that published from an IoT Hub device uses an older version of the SDK. This PR updates the sample to use the new version of Event Hubs SDK (azure-messaging-eventhubs version 5.1.0).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other: Update sample to use latest version of Event Hubs SDK

## How to Test
*  Get the code
```
git clone https://github.com/srnagar/azure-iot-samples-java
cd azure-iot-samples-java
git checkout eh-iot-sample
mvn clean install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Add your event hub compatible endpoint information by running Azure CLI, and run the code in ReadDeviceToCloudMessages.java. Send data to your IotHub via any means you are familiar with in another program.
```

## What to Check
Verify that the sample prints out messages that you have sent
